### PR TITLE
Externs files filtering for IDE

### DIFF
--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -62,6 +62,7 @@ data Command
     | List { listType :: ListType }
     | Rebuild FilePath (Maybe FilePath) (Set P.CodegenTarget)
     | RebuildSync FilePath (Maybe FilePath) (Set P.CodegenTarget)
+    | Focus [P.ModuleName]
     | Cwd
     | Reset
     | Quit
@@ -79,6 +80,7 @@ commandName c = case c of
   List{} -> "List"
   Rebuild{} -> "Rebuild"
   RebuildSync{} -> "RebuildSync"
+  Focus{} -> "Focus"
   Cwd{} -> "Cwd"
   Reset{} -> "Reset"
   Quit{} -> "Quit"
@@ -176,6 +178,13 @@ instance FromJSON Command where
           <$> params .: "file"
           <*> params .:? "actualFile"
           <*> (parseCodegenTargets =<< params .:? "codegen" .!= [ "js" ])
+      "focus" -> do
+        params' <- o .:? "params"
+        case params' of
+          Nothing -> 
+            pure (Focus [])
+          Just params ->
+            Focus <$> (map P.moduleNameFromString <$> params .:? "modules" .!= [])
       c -> fail ("Unknown command: " <> show c)
     where
       parseCodegenTargets ts =

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -65,7 +65,8 @@ import System.Directory (getModificationTime)
 resetIdeState :: Ide m => m ()
 resetIdeState = do
   ideVar <- ideStateVar <$> ask
-  liftIO (atomically (writeTVar ideVar emptyIdeState))
+  durableState <- getDurableState
+  liftIO (atomically (writeTVar ideVar (emptyIdeState { ideDurableState = durableState })))
 
 getOutputDirectory :: Ide m => m FilePath
 getOutputDirectory = do
@@ -145,21 +146,21 @@ setVolatileStateSTM ref vs = do
     x {ideVolatileState = vs}
   pure ()
 
--- | Retrieves the ModifierState from the State.
-getModifierState :: Ide m => m IdeModifierState
-getModifierState = do
+-- | Retrieves the DurableState from the State.
+getDurableState :: Ide m => m IdeDurableState
+getDurableState = do
   st <- ideStateVar <$> ask
-  liftIO (atomically (getModifierStateSTM st))
+  liftIO (atomically (getDurableStateSTM st))
 
--- | STM version of getModifierState
-getModifierStateSTM :: TVar IdeState -> STM IdeModifierState
-getModifierStateSTM ref = ideModifierState <$> readTVar ref
+-- | STM version of getDurableState
+getDurableStateSTM :: TVar IdeState -> STM IdeDurableState
+getDurableStateSTM ref = ideDurableState <$> readTVar ref
 
--- | Sets the ModifierState inside Ide's state
-setModifierStateSTM :: TVar IdeState -> IdeModifierState -> STM ()
-setModifierStateSTM ref md = do
+-- | Sets the DurableState inside Ide's state
+setDurableStateSTM :: TVar IdeState -> IdeDurableState -> STM ()
+setDurableStateSTM ref md = do
   modifyTVar ref $ \x ->
-    x {ideModifierState = md}
+    x {ideDurableState = md}
   pure ()
 
 -- | Checks if the given ModuleName matches the last rebuild cache and if it
@@ -471,7 +472,7 @@ resolveDataConstructorsForModule decls =
 
 getFocusedModules :: Ide m => m (Set P.ModuleName)
 getFocusedModules = do
-  IdeModifierState{mdFocusedModules = focusedModules} <- getModifierState
+  IdeDurableState{drFocusedModules = focusedModules} <- getDurableState
   pure focusedModules
 
 setFocusedModules :: Ide m => [P.ModuleName] -> m ()
@@ -481,5 +482,4 @@ setFocusedModules modulesToFocus = do
 
 setFocusedModulesSTM :: TVar IdeState -> [P.ModuleName] -> STM ()
 setFocusedModulesSTM ref modulesToFocus = do
-  IdeModifierState{} <- getModifierStateSTM ref
-  setModifierStateSTM ref (IdeModifierState (Set.fromList modulesToFocus))
+  setDurableStateSTM ref (IdeDurableState (Set.fromList modulesToFocus))

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -31,6 +31,9 @@ module Language.PureScript.Ide.State
   , populateVolatileStateSTM
   , getOutputDirectory
   , updateCacheTimestamp
+  , getFocusedModules
+  , setFocusedModules
+  , setFocusedModulesSTM
   -- for tests
   , resolveOperatorsForModule
   , resolveInstances
@@ -44,6 +47,7 @@ import Control.Lens (Ixed(..), preview, view, (%~), (.~), (^.))
 import "monad-logger" Control.Monad.Logger (MonadLogger, logWarnN)
 import Data.IORef (readIORef, writeIORef)
 import Data.Map.Lazy qualified as Map
+import Data.Set qualified as Set
 import Data.Time.Clock (UTCTime)
 import Data.Zip (unzip)
 import Language.PureScript qualified as P
@@ -139,6 +143,23 @@ setVolatileStateSTM :: TVar IdeState -> IdeVolatileState -> STM ()
 setVolatileStateSTM ref vs = do
   modifyTVar ref $ \x ->
     x {ideVolatileState = vs}
+  pure ()
+
+-- | Retrieves the ModifierState from the State.
+getModifierState :: Ide m => m IdeModifierState
+getModifierState = do
+  st <- ideStateVar <$> ask
+  liftIO (atomically (getModifierStateSTM st))
+
+-- | STM version of getModifierState
+getModifierStateSTM :: TVar IdeState -> STM IdeModifierState
+getModifierStateSTM ref = ideModifierState <$> readTVar ref
+
+-- | Sets the ModifierState inside Ide's state
+setModifierStateSTM :: TVar IdeState -> IdeModifierState -> STM ()
+setModifierStateSTM ref md = do
+  modifyTVar ref $ \x ->
+    x {ideModifierState = md}
   pure ()
 
 -- | Checks if the given ModuleName matches the last rebuild cache and if it
@@ -447,3 +468,18 @@ resolveDataConstructorsForModule decls =
       & mapMaybe (preview (idaDeclaration . _IdeDeclDataConstructor))
       & foldr (\(IdeDataConstructor name typeName type') ->
                   Map.insertWith (<>) typeName [(name, type')]) Map.empty
+
+getFocusedModules :: Ide m => m (Set P.ModuleName)
+getFocusedModules = do
+  IdeModifierState{mdFocusedModules = focusedModules} <- getModifierState
+  pure focusedModules
+
+setFocusedModules :: Ide m => [P.ModuleName] -> m ()
+setFocusedModules modulesToFocus = do
+  st <- ideStateVar <$> ask
+  liftIO (atomically (setFocusedModulesSTM st modulesToFocus)) 
+
+setFocusedModulesSTM :: TVar IdeState -> [P.ModuleName] -> STM ()
+setFocusedModulesSTM ref modulesToFocus = do
+  IdeModifierState{} <- getModifierStateSTM ref
+  setModifierStateSTM ref (IdeModifierState (Set.fromList modulesToFocus))

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -178,10 +178,11 @@ type Ide m = (MonadIO m, MonadReader IdeEnvironment m)
 data IdeState = IdeState
   { ideFileState :: IdeFileState
   , ideVolatileState :: IdeVolatileState
+  , ideModifierState :: IdeModifierState
   } deriving (Show)
 
 emptyIdeState :: IdeState
-emptyIdeState = IdeState emptyFileState emptyVolatileState
+emptyIdeState = IdeState emptyFileState emptyVolatileState emptyModifierState
 
 emptyFileState :: IdeFileState
 emptyFileState = IdeFileState M.empty M.empty
@@ -189,6 +190,8 @@ emptyFileState = IdeFileState M.empty M.empty
 emptyVolatileState :: IdeVolatileState
 emptyVolatileState = IdeVolatileState (AstData M.empty) M.empty Nothing
 
+emptyModifierState :: IdeModifierState
+emptyModifierState = IdeModifierState mempty
 
 -- | @IdeFileState@ holds data that corresponds 1-to-1 to an entity on the
 -- filesystem. Externs correspond to the ExternsFiles the compiler emits into
@@ -211,6 +214,10 @@ data IdeVolatileState = IdeVolatileState
   { vsAstData :: AstData P.SourceSpan
   , vsDeclarations :: ModuleMap [IdeDeclarationAnn]
   , vsCachedRebuild :: Maybe (P.ModuleName, P.ExternsFile)
+  } deriving (Show)
+
+data IdeModifierState = IdeModifierState
+  { mdFocusedModules :: Set P.ModuleName
   } deriving (Show)
 
 newtype Match a = Match (P.ModuleName, a)


### PR DESCRIPTION
This implements an additional command in the IDE for filtering which externs files get loaded at startup. This also involves using a forked version of the `purescript-language-server` and VSCode extension for support.